### PR TITLE
[I-2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ up:
 	./bin/generate_kube_config.sh
 	./bin/generate_encryption.sh
 	docker-compose up -d
+	mv ~/.kube/config{,.bak}
+	cp conf/admin.yaml ~/.kube/config
 
 clean:
 	docker-compose down
@@ -11,3 +13,5 @@ clean:
 	rm -f certs/*csr
 	rm -f conf/*
 	rm -rf /tmp/etcd
+	rm -f ~/.kube/config
+	mv ~/.kube/config{.bak,}

--- a/README.md
+++ b/README.md
@@ -47,41 +47,21 @@ make up
 This invokes docker-compose up -d after generating certificates. You can confirm your apiserver and etcd are up by making a request to your local apiserver:
 
 ```
-curl http://localhost:8080/version
+curl --cacert certs/ca.pem https://127.0.0.1:6443/
 {
-  "major": "1",
-  "minor": "12",
-  "gitVersion": "v1.12.2",
-  "gitCommit": "17c77c7898218073f14c8d573582e8d2313dc740",
-  "gitTreeState": "clean",
-  "buildDate": "2018-10-24T06:43:59Z",
-  "goVersion": "go1.10.4",
-  "compiler": "gc",
-  "platform": "linux/amd64"
-}%
-```
+  "kind": "Status",
+  "apiVersion": "v1",
+  "metadata": {
 
-To see a full list of available API endpoints, you can run:
-```
-curl http://localhost:8080/
-{
-  "paths": [
-    "/api",
-    "/api/v1",
-    "/apis",
-    "/apis/",
-    "/apis/admissionregistration.k8s.io",
-    "/apis/admissionregistration.k8s.io/v1beta1",
-    "/apis/apiextensions.k8s.io",
-    "/apis/apiextensions.k8s.io/v1beta1",
-    "/apis/apiregistration.k8s.io",
-    "/apis/apiregistration.k8s.io/v1",
-    "/apis/apiregistration.k8s.io/v1beta1",
-    "/apis/apps",
-    "/apis/apps/v1",
-    "/apis/apps/v1beta1",
-    "/apis/apps/v1beta2",
-[TRUNCATED]
+  },
+  "status": "Failure",
+  "message": "forbidden: User \"system:anonymous\" cannot get path \"/\"",
+  "reason": "Forbidden",
+  "details": {
+
+  },
+  "code": 403
+}
 ```
 
 To learn more about the kubernetes apiserver, see: [The Kubernetes API](https://kubernetes.io/docs/concepts/overview/kubernetes-api/)
@@ -105,22 +85,17 @@ kube-apiserver_1  | I1101 02:22:08.679688       1 storage_scheduling.go:91] crea
 kube-apiserver_1  | I1101 02:22:08.679925       1 storage_scheduling.go:100] all system priority classes are created successfully or already exist.
 ```
 
-Try the same while replacing kube-apiserver with etcd to see more about what etcd is doing.
-
-TODO:
-
-- [] Setup etcd cluster w/ TLS
-- [] Configure Kubernetes apiserver to use TLS for etcd
+Try `docker-compose logs etcd-0` to see more about what etcd is doing.
 
 # etcd
 
-etcd starts up with [bin/etcd_entry.sh](bin/etcd_entry.sh).
+etcd starts up with [bin/etcd_entrypoint.sh](bin/etcd_entrypoint.sh).
 
 To test the health of your cluster, run:
 
 ```
 docker-compose exec etcd etcdctl member list
-1dc00bcbf8c1a1fc: name=etcd peerURLs=http://192.168.112.2:2380 clientURLs=http://192.168.112.2:2379 isLeader=true
+1dc00bcbf8c1a1fc: name=etcd peerURLs=https://192.168.112.2:2380 clientURLs=https://192.168.112.2:2379 isLeader=true
 ```
 
 Currently, we only have 1 etcd node. Ideally, we'd have no less than 3, but this does allow us to explore the data stored in etcd. _NOTE_: We set `ETCDCTL_API=3` in [docker-compose.yml](docker-compose.yml) so that etcdctl uses the version 3 etcd api. You can see a list of available functions with the help flag:

--- a/bin/apiserver_entrypoint.sh
+++ b/bin/apiserver_entrypoint.sh
@@ -23,9 +23,9 @@ kube-apiserver \
         --enable-admission-plugins=Initializers,NamespaceLifecycle,NodeRestriction,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota \
         --enable-swagger-ui=true \
         --etcd-cafile=/certs/ca.pem \
-        --etcd-certfile=/certs/kubernetes.pem \
-        --etcd-keyfile=/certs/kubernetes-key.pem \
-        --etcd-servers=https://etcd-0:2379 \
+        --etcd-certfile=/certs/etcd.pem \
+        --etcd-keyfile=/certs/etcd-key.pem \
+        --etcd-servers=https://etcd-0:2380 \
         --event-ttl=1h \
         --experimental-encryption-provider-config=/conf/encryption-config.yaml \
         --kubelet-certificate-authority=/certs/ca.pem \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,9 +10,8 @@ services:
       - ./bin:/scripts/
       - ./certs:/certs
       - /tmp/etcd:/var/lib/etcd
-    network_mode: host
 
-  # latest Hyperkube tags can be found here:
+  # Latest Hyperkube tags can be found here:
   # https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/hyperkube?authuser=2&gcrImageListsize=50
   kube-apiserver:
     image: gcr.io/google-containers/hyperkube:v1.12.2
@@ -20,12 +19,12 @@ services:
     depends_on:
       - etcd-0
     ports:
+      - 6443:6443
       - 8080:8080
     volumes:
       - ./bin:/scripts
       - ./certs:/certs
       - ./conf:/conf
-    network_mode: host
 
   kube-controller-manager:
     image: gcr.io/google-containers/hyperkube:v1.12.2
@@ -41,6 +40,3 @@ services:
     volumes:
       - ./conf:/conf
       - ./bin:/scripts
-    network_mode: host
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
       - etcd-0
     ports:
       - 6443:6443
-      - 8080:8080
     volumes:
       - ./bin:/scripts
       - ./certs:/certs


### PR DESCRIPTION
Fixes #2.

In this PR, I update the apiserver to set the correct cert and port. 

I also broke out the entrypoint from the `docker-compose.yml` file so that it can be more readable, since there are so many flags that are necessary.

One of note is the admission controllers configuration flag, which has the 7 of the 12 default admissions controllers configured. 

I changed the port to port 6443 so we can curl and otherwise access the apiserver over the secured protocol. 